### PR TITLE
Fix/69 competition status UI

### DIFF
--- a/src/hooks/solve/useContest.ts
+++ b/src/hooks/solve/useContest.ts
@@ -31,6 +31,7 @@ type ContestInfo = {
   endDate?: string;
   status?: string;
 };
+type ContestPhase = "BEFORE" | "ONGOING" | "ENDED"; //대회 상태를 나타내는 타입 추가
 
 interface UseContestProps {
   contestCode?: string;

--- a/src/hooks/solve/useContest.ts
+++ b/src/hooks/solve/useContest.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from "react";
 import { EventSourcePolyfill } from "event-source-polyfill";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { z } from "zod";
 import axiosInstance from "../../api/axiosInstance";
@@ -31,7 +31,9 @@ type ContestInfo = {
   endDate?: string;
   status?: string;
 };
-type ContestPhase = "BEFORE" | "ONGOING" | "ENDED"; //대회 상태를 나타내는 타입 추가
+
+// 제출/화면 분기에 쓰는 시간 기준 대회 상태
+type ContestPhase = "BEFORE" | "ONGOING" | "ENDED";
 
 interface UseContestProps {
   contestCode?: string;
@@ -42,8 +44,11 @@ export function useContest({ contestCode, problemId }: UseContestProps) {
   const [problems, setProblems] = useState<ContestProblemItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [contestInfo, setContestInfo] = useState<ContestInfo | null>(null);
+  const [contestPhase, setContestPhase] = useState<ContestPhase>("BEFORE");
   const [timeLeft, setTimeLeft] = useState("");
-  const [timeSpentByProblem, setTimeSpentByProblem] = useState<Record<string, number>>(() => {
+  const [timeSpentByProblem, setTimeSpentByProblem] = useState<
+    Record<string, number>
+  >(() => {
     try {
       const stored = localStorage.getItem(`dukkaebi_timeSpent_${contestCode}`);
       return stored ? JSON.parse(stored) : {};
@@ -63,10 +68,15 @@ export function useContest({ contestCode, problemId }: UseContestProps) {
       try {
         setIsLoading(true);
         const accessToken = localStorage.getItem("accessToken");
-        const res = await axiosInstance(`${API_BASE_URL}contest/${contestCode}`, {
-          signal: controller.signal,
-          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
-        });
+        const res = await axiosInstance(
+          `${API_BASE_URL}contest/${contestCode}`,
+          {
+            signal: controller.signal,
+            headers: accessToken
+              ? { Authorization: `Bearer ${accessToken}` }
+              : undefined,
+          },
+        );
 
         const data = contestResponseSchema.parse(res.data);
         setContestInfo({
@@ -152,7 +162,7 @@ export function useContest({ contestCode, problemId }: UseContestProps) {
         try {
           localStorage.setItem(
             `dukkaebi_timeSpent_${contestCode}`,
-            JSON.stringify(newTimes)
+            JSON.stringify(newTimes),
           );
         } catch (e) {
           console.error("Failed to save time spent:", e);
@@ -165,20 +175,26 @@ export function useContest({ contestCode, problemId }: UseContestProps) {
     return () => clearInterval(timer);
   }, [problemId, contestCode]);
 
-  // Live countdown
+  // 남은 시간과 제출 가능 상태를 같은 기준으로 갱신
   useEffect(() => {
     if (!contestInfo) {
       setTimeLeft("");
+      setContestPhase("BEFORE");
       return;
     }
 
     const compute = () => {
       const now = new Date();
-      const start = contestInfo.startDate ? new Date(contestInfo.startDate) : null;
+      const start = contestInfo.startDate
+        ? new Date(contestInfo.startDate)
+        : null;
       const end = contestInfo.endDate ? new Date(contestInfo.endDate) : null;
-      const status = contestInfo.status;
+      const status = contestInfo.status?.toUpperCase();
 
-      if (status === "ENDED" || (end && now > end)) return "종료됨";
+      if (status === "ENDED" || (end && now > end)) {
+        setContestPhase("ENDED");
+        return "종료됨";
+      }
 
       const fmt = (ms: number) => {
         const totalSec = Math.max(0, Math.floor(ms / 1000));
@@ -192,8 +208,15 @@ export function useContest({ contestCode, problemId }: UseContestProps) {
         return d > 0 ? `D-${d} ${hh}:${mm}:${ss}` : `${hh}:${mm}:${ss}`;
       };
 
-      if (start && now < start) return `시작까지 ${fmt(start.getTime() - now.getTime())}`;
-      if (end && now < end) return `종료까지 ${fmt(end.getTime() - now.getTime())}`;
+      if (start && now < start) {
+        setContestPhase("BEFORE");
+        return `시작까지 ${fmt(start.getTime() - now.getTime())}`;
+      }
+      if (end && now < end) {
+        setContestPhase("ONGOING");
+        return `종료까지 ${fmt(end.getTime() - now.getTime())}`;
+      }
+      setContestPhase("ONGOING");
       return "";
     };
 
@@ -210,6 +233,7 @@ export function useContest({ contestCode, problemId }: UseContestProps) {
     problems,
     isLoading,
     contestInfo,
+    contestPhase,
     timeLeft,
     getTimeSpent,
   };

--- a/src/page/solve/contests/index.tsx
+++ b/src/page/solve/contests/index.tsx
@@ -106,7 +106,7 @@ export default function SolvePage() {
     testCode(code, language);
   };
 
-  const isContestOngoing = contestPhase === "ONGOING";
+  const isContestOngoing = contestPhase === "ONGOING"; // 제출/테스트 허용 여부
 
   const handleSubmitCode = () => {
     // 대회 제출은 진행 중 상태에서만 허용

--- a/src/page/solve/contests/index.tsx
+++ b/src/page/solve/contests/index.tsx
@@ -57,6 +57,7 @@ export default function SolvePage() {
   const {
     problems: courseProblems,
     timeLeft,
+    contestPhase,
     getTimeSpent,
   } = useContest({
     contestCode,
@@ -105,7 +106,15 @@ export default function SolvePage() {
     testCode(code, language);
   };
 
+  const isContestOngoing = contestPhase === "ONGOING";
+
   const handleSubmitCode = () => {
+    // 대회 제출은 진행 중 상태에서만 허용
+    if (!isContestOngoing) {
+      alert("대회 진행 중에만 제출할 수 있습니다.");
+      return;
+    }
+
     saveToLocalStorage();
     const { code, language } = getValues();
     submitCode(code, language, getTimeSpent(problemId));
@@ -223,7 +232,7 @@ export default function SolvePage() {
                 </Style.SubmitButton>
                 <Style.SubmitButton
                   onClick={handleSubmitCode}
-                  disabled={!problemId || isSubmitting}
+                  disabled={!problemId || isSubmitting || !isContestOngoing}
                 >
                   {isSubmitting ? "제출 중..." : "제출"}
                 </Style.SubmitButton>


### PR DESCRIPTION
## 변경 사항

- 대회 진행 상태 타입 및 상태값 추가
- 대회 시간 기준으로 시작 전/진행 중/종료 상태를 계산하도록 변경
- 진행 중인 대회에서만 코드 제출이 가능하도록 제출 버튼 및 제출 로직 제한
