### PR TITLE
fix: 401 동시 발생 시 토큰 재발급 단일 호출로 통합

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -18,6 +18,31 @@ axiosInstance.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+// 동시에 여러 401이 떠도 재발급은 한 번만 타도록 진행 중인 refresh를 공유
+let refreshPromise: Promise<string> | null = null;
+
+const refreshAccessToken = (): Promise<string> => {
+  if (!refreshPromise) {
+    refreshPromise = axios
+      .post(`${apiUrl}/auth/refresh`, {
+        token: localStorage.getItem("refreshToken"),
+      })
+      .then((response) => {
+        const { accessToken, refreshToken } = response.data;
+        localStorage.setItem("accessToken", accessToken);
+        // 토큰 회전 도입 시 새 refreshToken도 함께 내려오면 교체
+        if (refreshToken) {
+          localStorage.setItem("refreshToken", refreshToken);
+        }
+        return accessToken;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+  return refreshPromise;
+};
+
 // 응답 인터셉터: 401 시 토큰 재발급 후 재요청, 실패 시 로그인 이동
 axiosInstance.interceptors.response.use(
   (response) => response,
@@ -28,13 +53,8 @@ axiosInstance.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const refreshToken = localStorage.getItem("refreshToken");
-        const response = await axios.post(`${apiUrl}/auth/refresh`, {
-          token: refreshToken,
-        });
-
-        const { accessToken } = response.data;
-        localStorage.setItem("accessToken", accessToken);
+        // 이미 진행 중인 재발급이 있으면 그 결과를 기다렸다가 재시도
+        const accessToken = await refreshAccessToken();
 
         // 기존 요청 헤더에 새 토큰 적용
         originalRequest.headers.Authorization = `Bearer ${accessToken}`;


### PR DESCRIPTION
## 관련 이슈
- Resolves #73 

## 변경 내용
- 진행 중인 refresh Promise를 모듈 레벨에서 공유해서, 동시에 여러 401이 발생해도 /auth/refresh가 한 번만 호출되도록 수정
- 나머지 요청들은 진행 중인 재발급 결과를 기다렸다가 새 토큰으로 재시도
- refresh 응답에 새 refreshToken이 포함되어 내려오는 경우 저장하도록 추가 

## 작업 목적
- 현재는 accessToken 만료 시 401을 받은 요청 수만큼 /auth/refresh가 병렬로 호출됨
- 서버에 리프레시 토큰 회전이 도입되면 첫 재발급이 기존 refreshToken을 무효화해서 나머지 재발급이 전부 실패 → 랜덤 로그아웃 발생
- 회전 도입 전에 프론트 재발급 구조를 미리 정리

## 테스트 방법
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료
- 로그인 후 localStorage의 accessToken을 임의 값으로 훼손 → 대회 상세 페이지 새로고침
- Network 탭에서 401 2건 발생 시 /auth/refresh가 1회만 호출되고, 실패했던 요청들이 재시도되어 200으로 성공하는 것 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [x] Breaking Changes가 없습니다

## 기타 사항