### PR TITLE
refactor: 페이지에 흩어진 axiosInstance 직접 호출을 도메인별 api 모듈로 통합

### DIFF
--- a/src/api/contestApi.ts
+++ b/src/api/contestApi.ts
@@ -1,0 +1,36 @@
+import axiosInstance from "./axiosInstance";
+
+export const contestApi = {
+  // 대회 목록 조회
+  getContests: async <T = unknown>(page: number = 0, size: number = 12) => {
+    const res = await axiosInstance.get<T>(`/contest/list`, {
+      params: { page, size },
+    });
+    return res.data;
+  },
+
+  // 대회 상세 조회
+  getContest: async <T = unknown>(
+    code: string | number,
+    config?: { signal?: AbortSignal },
+  ) => {
+    const res = await axiosInstance.get<T>(`/contest/${code}`, {
+      signal: config?.signal,
+    });
+    return res.data;
+  },
+
+  // 대회 참가 (참여 코드 필요)
+  joinContest: async (code: string | number, joinCode: string) => {
+    const res = await axiosInstance.post(
+      `/student/contest/${code}/join`,
+      null,
+      {
+        params: { code: joinCode },
+      },
+    );
+    return res.data;
+  },
+};
+
+export default contestApi;

--- a/src/api/courseApi.ts
+++ b/src/api/courseApi.ts
@@ -1,0 +1,35 @@
+import axiosInstance from "./axiosInstance";
+
+export const courseApi = {
+  // 코스 상세 조회
+  getCourse: async <T = unknown>(id: string | number) => {
+    const res = await axiosInstance.get<T>(`/course/${id}`);
+    return res.data;
+  },
+
+  // 수강 신청
+  joinCourse: async (id: string | number) => {
+    const res = await axiosInstance.post(`/student/course/${id}/join`);
+    return res.data;
+  },
+
+  // 학습 중인 코스 목록
+  getInProgressCourses: async <T = unknown>() => {
+    const res = await axiosInstance.get<T>(`/student/course/in-progress`);
+    return res.data;
+  },
+
+  // 완료한 코스 목록
+  getCompletedCourses: async <T = unknown>() => {
+    const res = await axiosInstance.get<T>(`/student/course/completed`);
+    return res.data;
+  },
+
+  // 수강 가능한 코스 목록
+  getJoinableCourses: async <T = unknown>() => {
+    const res = await axiosInstance.get<T>(`/student/course/joinable`);
+    return res.data;
+  },
+};
+
+export default courseApi;

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -1,0 +1,33 @@
+import axiosInstance from "./axiosInstance";
+
+export const noticeApi = {
+  // 공지사항 목록 조회 (페이지네이션)
+  getNotices: async <T = unknown>(page: number = 0, size: number = 15) => {
+    const res = await axiosInstance.get<T>(`/notice`, {
+      params: { page, size },
+    });
+    return res.data;
+  },
+
+  // 공지사항 검색
+  searchNotices: async <T = unknown>(keyword: string) => {
+    const res = await axiosInstance.get<T>(`/notice/search`, {
+      params: { keyword },
+    });
+    return res.data;
+  },
+
+  // 공지사항 상세 조회
+  getNotice: async <T = unknown>(id: string | number) => {
+    const res = await axiosInstance.get<T>(`/notice/${id}`);
+    return res.data;
+  },
+
+  // 홈 화면용 공지사항 목록
+  getHomeNotices: async <T = unknown>() => {
+    const res = await axiosInstance.get<T>(`/notice/home`);
+    return res.data;
+  },
+};
+
+export default noticeApi;

--- a/src/api/problemApi.ts
+++ b/src/api/problemApi.ts
@@ -1,0 +1,11 @@
+import axiosInstance from "./axiosInstance";
+
+export const problemApi = {
+  // 문제 목록 조회 (필터/정렬/검색 파라미터 포함)
+  getProblems: async <T = unknown>(params: Record<string, unknown>) => {
+    const res = await axiosInstance.get<T>(`/problems`, { params });
+    return res.data;
+  },
+};
+
+export default problemApi;

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -1,0 +1,37 @@
+import axiosInstance from "./axiosInstance";
+
+export const userApi = {
+  // 내 정보 조회
+  getUser: async <T = unknown>() => {
+    const res = await axiosInstance.get<T>(`/user`);
+    return res.data;
+  },
+
+  // 로그아웃
+  logout: async () => {
+    const res = await axiosInstance.post(`/user/logout`);
+    return res.data;
+  },
+
+  // 회원탈퇴
+  deleteAccount: async () => {
+    const res = await axiosInstance.delete(`/user/delete`);
+    return res.data;
+  },
+
+  // 날짜별 문제 풀이 수 (히트맵)
+  getContributions: async <T = unknown>(start: string, end: string) => {
+    const res = await axiosInstance.get<T>(`/user/activity/contributions`, {
+      params: { start, end },
+    });
+    return res.data;
+  },
+
+  // 연속 풀이 일수
+  getStreak: async <T = unknown>() => {
+    const res = await axiosInstance.get<T>(`/user/activity/streak`);
+    return res.data;
+  },
+};
+
+export default userApi;

--- a/src/hooks/solve/useContest.ts
+++ b/src/hooks/solve/useContest.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { EventSourcePolyfill } from "event-source-polyfill";
 import { toast } from "react-toastify";
 import { z } from "zod";
-import axiosInstance from "../../api/axiosInstance";
+import contestApi from "../../api/contestApi";
 
 const API_BASE_URL = (() => {
   const raw = import.meta.env.VITE_API_URL;
@@ -61,13 +61,11 @@ export function useContest({ contestCode, problemId }: UseContestProps) {
     const fetchContest = async () => {
       try {
         setIsLoading(true);
-        const accessToken = localStorage.getItem("accessToken");
-        const res = await axiosInstance(`${API_BASE_URL}contest/${contestCode}`, {
+        const res = await contestApi.getContest(contestCode, {
           signal: controller.signal,
-          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
         });
 
-        const data = contestResponseSchema.parse(res.data);
+        const data = contestResponseSchema.parse(res);
         setContestInfo({
           startDate: data.startDate,
           endDate: data.endDate,

--- a/src/page/contests/info/index.tsx
+++ b/src/page/contests/info/index.tsx
@@ -1,5 +1,5 @@
 import * as S from "./style";
-import axiosInstance from "../../../api/axiosInstance";
+import contestApi from "../../../api/contestApi";
 import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { Header } from "../../../components/header";
@@ -106,17 +106,13 @@ const ContestDetailPage = () => {
       const input = prompt("대회 코드를 입력해주세요.");
       if (!input) return;
 
-      axiosInstance
-        .post(`/student/contest/${contestDetails.code}/join`, null, {
-          params: { code: input },
-        })
+      contestApi
+        .joinContest(contestDetails.code, input)
         .then(() => {
           toast.success("대회 참가에 성공했습니다.");
-          axiosInstance
-            .get<ContestDetail>(`/contest/${contestCode}`)
-            .then((response) => {
-              setContestDetails(response.data);
-            });
+          contestApi.getContest<ContestDetail>(contestCode).then((data) => {
+            setContestDetails(data);
+          });
         })
         .catch(() => {
           toast.error("대회 코드가 일치하지 않거나 참여할 수 없습니다.");
@@ -130,10 +126,8 @@ const ContestDetailPage = () => {
   useEffect(() => {
     const fetchContestDetails = async () => {
       try {
-        const response = await axiosInstance.get<ContestDetail>(
-          `/contest/${contestCode}`,
-        );
-        setContestDetails(response.data);
+        const data = await contestApi.getContest<ContestDetail>(contestCode);
+        setContestDetails(data);
 
         if (contestCode) {
           localStorage.removeItem(`dukkaebi_codes${contestCode}`);

--- a/src/page/contests/info/index.tsx
+++ b/src/page/contests/info/index.tsx
@@ -124,19 +124,19 @@ const ContestDetailPage = () => {
   };
 
   useEffect(() => {
+    if (!contestCode) return;
+
     const fetchContestDetails = async () => {
       try {
         const data = await contestApi.getContest<ContestDetail>(contestCode);
         setContestDetails(data);
 
-        if (contestCode) {
-          localStorage.removeItem(`dukkaebi_codes${contestCode}`);
-          localStorage.removeItem(`dukkaebi_langs_${contestCode}`);
-          localStorage.removeItem(`dukkaebi_timeSpent_${contestCode}`);
-          console.log(
-            `Contest ${contestCode} 관련 로컬 데이터가 초기화되었습니다.`,
-          );
-        }
+        localStorage.removeItem(`dukkaebi_codes${contestCode}`);
+        localStorage.removeItem(`dukkaebi_langs_${contestCode}`);
+        localStorage.removeItem(`dukkaebi_timeSpent_${contestCode}`);
+        console.log(
+          `Contest ${contestCode} 관련 로컬 데이터가 초기화되었습니다.`,
+        );
       } catch (error) {
         console.error("Error fetching contest details:", error);
       }

--- a/src/page/contests/list/index.tsx
+++ b/src/page/contests/list/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { Header } from "../../../components/header";
 import { Footer } from "../../../components/footer";
-import axiosInstance from "../../../api/axiosInstance";
+import contestApi from "../../../api/contestApi";
 import { useNavigate } from "react-router-dom";
 import * as S from "./style";
 import {
@@ -55,11 +55,10 @@ const ContestPage = () => {
   useEffect(() => {
     const fetchContests = async () => {
       try {
-        const res = await axiosInstance.get(`/contest/list`, {
-          params: { page: currentPage - 1, size: 12 },
-        });
-
-        const data = res.data;
+        const data = await contestApi.getContests<{
+          content: ContestAPIResponse[];
+          totalPages: number;
+        }>(currentPage - 1, 12);
 
         if (data && Array.isArray(data.content)) {
           const mappedContests = data.content.map((c: ContestAPIResponse) => ({

--- a/src/page/courses/explore/explore.tsx
+++ b/src/page/courses/explore/explore.tsx
@@ -5,7 +5,7 @@ import { Header } from "../../../components/header";
 import { Footer } from "../../../components/footer";
 import * as S from "./style";
 import { SearchBar, CourseCard, Pagination } from "../../../components/courses/explore";
-import axiosInstance from "../../../api/axiosInstance";
+import courseApi from "../../../api/courseApi";
 
 interface CourseItem {
   id: string;
@@ -28,10 +28,10 @@ const CoursePage = () => {
     const fetchJoinableCourses = async () => {
       setLoading(true);
       try {
-        const res = await axiosInstance.get("/student/course/joinable");
-        if (Array.isArray(res.data)) {
+        const res = await courseApi.getJoinableCourses();
+        if (Array.isArray(res)) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const data = res.data as any[];
+          const data = res as any[];
           console.log(data);
           const mapped = data.map<CourseItem>((it) => ({
             id: String(it.courseId ?? it.id ?? it.code ?? it.title),

--- a/src/page/courses/index.tsx
+++ b/src/page/courses/index.tsx
@@ -11,7 +11,8 @@ import wisp from "../../assets/image/profile/dubi-rank/wisp.png";
 
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import axiosInstance from "../../api/axiosInstance";
+import courseApi from "../../api/courseApi";
+import userApi from "../../api/userApi";
 import { ProfileSection, Tabs, CourseGrid, Pagination } from "../../components/courses";
 
 interface CourseItem {
@@ -116,14 +117,14 @@ export default function CoursesPage() {
         });
 
         // 사용자 정보 조회
-        const userRes = await axiosInstance.get("/user");
-        if (userRes.data) {
-          setUserInfo(userRes.data);
+        const user = await userApi.getUser<UserInfo>();
+        if (user) {
+          setUserInfo(user);
         }
 
         const [inProgressRes, completedRes] = await Promise.allSettled([
-          axiosInstance.get("/student/course/in-progress"),
-          axiosInstance.get("/student/course/completed"),
+          courseApi.getInProgressCourses(),
+          courseApi.getCompletedCourses(),
         ]);
 
         const nextCourses: CourseItem[] = [];
@@ -132,10 +133,10 @@ export default function CoursesPage() {
 
         if (
           inProgressRes.status === "fulfilled" &&
-          Array.isArray(inProgressRes.value.data)
+          Array.isArray(inProgressRes.value)
         ) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const data = inProgressRes.value.data as any[];
+          const data = inProgressRes.value as any[];
           inProgressCount = data.length;
           nextCourses.push(
             ...data.map<CourseItem>((it) => ({
@@ -154,7 +155,7 @@ export default function CoursesPage() {
 
         if (completedRes.status === "fulfilled") {
           // 응답 스키마: { inProgressCount: number, courses: [...] }
-          const raw = completedRes.value.data as any;
+          const raw = completedRes.value as any;
           const list = Array.isArray(raw)
             ? (raw as any[])
             : Array.isArray(raw?.courses)
@@ -197,8 +198,8 @@ export default function CoursesPage() {
     const fetchCompletedTab = async () => {
       try {
         const [inProgressRes, completedRes] = await Promise.allSettled([
-          axiosInstance.get("/student/course/in-progress"),
-          axiosInstance.get("/student/course/completed"),
+          courseApi.getInProgressCourses(),
+          courseApi.getCompletedCourses(),
         ]);
 
         const nextCourses: CourseItem[] = [];
@@ -207,10 +208,10 @@ export default function CoursesPage() {
 
         if (
           inProgressRes.status === "fulfilled" &&
-          Array.isArray(inProgressRes.value.data)
+          Array.isArray(inProgressRes.value)
         ) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const data = inProgressRes.value.data as any[];
+          const data = inProgressRes.value as any[];
           inProgressCount = data.length;
           nextCourses.push(
             ...data.map<CourseItem>((it) => ({
@@ -228,7 +229,7 @@ export default function CoursesPage() {
         }
 
         if (completedRes.status === "fulfilled") {
-          const raw = completedRes.value.data as any;
+          const raw = completedRes.value as any;
           const list = Array.isArray(raw)
             ? (raw as any[])
             : Array.isArray(raw?.courses)

--- a/src/page/courses/info/index.tsx
+++ b/src/page/courses/info/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Header } from "../../../components/header";
-import axiosInstance from "../../../api/axiosInstance";
+import courseApi from "../../../api/courseApi";
 import * as S from "./style";
 import { IntroSection, ProblemsTable, SideCard } from "../../../components/courses/info";
 
@@ -148,10 +148,8 @@ const CourseDetailPage = () => {
     setError(null);
 
     try {
-      const response = await axiosInstance.get<ApiCourseDetail>(
-        `/course/${id}`
-      );
-      setCourseData(mapCourseDetail(response.data));
+      const data = await courseApi.getCourse<ApiCourseDetail>(id);
+      setCourseData(mapCourseDetail(data));
     } catch (err) {
       console.error("Failed to fetch course detail:", err);
       setError("코스 정보를 불러오지 못했습니다.");
@@ -178,7 +176,7 @@ const CourseDetailPage = () => {
     if (!courseId || joinLoading || courseData.isJoined) return;
     setJoinLoading(true);
     try {
-      await axiosInstance.post(`/student/course/${courseId}/join`);
+      await courseApi.joinCourse(courseId);
       setCourseData((prev) => ({ ...prev, isJoined: true }));
       await fetchCourseDetail(courseId);
     } catch (err) {

--- a/src/page/main/index.tsx
+++ b/src/page/main/index.tsx
@@ -3,7 +3,8 @@ import * as S from "./styles";
 import { Header } from "../../components/header";
 import { Footer } from "../../components/footer";
 import { HeroSection, StatsCard, NoticeSection } from "../../components/main";
-import axiosInstance from "../../api/axiosInstance";
+import noticeApi from "../../api/noticeApi";
+import userApi from "../../api/userApi";
 import { useNavigate } from "react-router-dom";
 
 type ContributionsResponse = Record<string, number>;
@@ -119,33 +120,25 @@ const Main = () => {
 
         const [contributionsResponse, streakResponse, noticeResponse] =
           await Promise.all([
-            axiosInstance.get<ContributionsResponse>(
-              "/user/activity/contributions",
-              {
-                params: {
-                  start: formatDate(contributionsStart),
-                  end: formatDate(contributionsEnd),
-                },
-              },
+            userApi.getContributions<ContributionsResponse>(
+              formatDate(contributionsStart),
+              formatDate(contributionsEnd),
             ),
-            axiosInstance.get<StreakResponse>("/user/activity/streak"),
-            axiosInstance.get<{ content: Notice[] }>("/notice/home"),
+            userApi.getStreak<StreakResponse>(),
+            noticeApi.getHomeNotices<{ content: Notice[] }>(),
           ]);
 
         const contributionsData =
-          (contributionsResponse.data as any)?.data ||
-          contributionsResponse.data ||
-          {};
+          (contributionsResponse as any)?.data || contributionsResponse || {};
         setContributions(contributionsData);
 
-        const streakData =
-          (streakResponse.data as any)?.data || streakResponse.data;
+        const streakData = (streakResponse as any)?.data || streakResponse;
         setStreak(
           typeof streakData?.streak === "number" ? streakData.streak : 0,
         );
 
         const noticeData =
-          (noticeResponse.data as any)?.content || noticeResponse.data || [];
+          (noticeResponse as any)?.content || noticeResponse || [];
         setNotices(noticeData.slice(0, 5));
       } catch (error) {
         console.error("Failed to load home data:", error);

--- a/src/page/notifications/info/index.tsx
+++ b/src/page/notifications/info/index.tsx
@@ -4,9 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Header } from "../../../components/header";
 import { Footer } from "../../../components/footer";
 import * as S from "./style";
-import axiosInstance from "../../../api/axiosInstance";
-// TODO: Uncomment when API is ready
-// import axiosInstance from "../../../api/axiosInstance";
+import noticeApi from "../../../api/noticeApi";
 
 interface NoticeDetail {
   title: string;
@@ -25,12 +23,12 @@ export default function NoticeInfoPage() {
 
   useEffect(() => {
     const fetchNotice = async () => {
-      if (hasFetched.current) return;
+      if (!id || hasFetched.current) return;
       hasFetched.current = true;
       
       try {
-        const response = await axiosInstance.get(`/notice/${id}`);
-        setNotice(response.data);
+        const data = await noticeApi.getNotice<NoticeDetail>(id);
+        setNotice(data);
       } catch (error) {
         console.error("Error fetching notice:", error);
       } finally {

--- a/src/page/notifications/list/index.tsx
+++ b/src/page/notifications/list/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Header } from "../../../components/header";
 import { Footer } from "../../../components/footer";
-import axiosInstance from "../../../api/axiosInstance";
+import noticeApi from "../../../api/noticeApi";
 import { SearchBar, NoticeTable, Pagination } from "../../../components/notifications";
 
 import {
@@ -43,16 +43,11 @@ export default function NoticesPage() {
     size: number = 15
   ): Promise<NoticePageResponse> => {
     try {
-      const res = await axiosInstance.get<NoticePageResponse>("/notice", {
-        params: {
-          page: page,
-          size: size,
-        },
-      });
-      const pageNumbers = Array.from({ length: res.data.totalPages }, (_, i) => i + 1);
+      const data = await noticeApi.getNotices<NoticePageResponse>(page, size);
+      const pageNumbers = Array.from({ length: data.totalPages }, (_, i) => i + 1);
       setPageArray(pageNumbers);
-      setTotalPages(res.data.totalPages);
-      return res.data;
+      setTotalPages(data.totalPages);
+      return data;
     } catch (error) {
       console.error("Error fetching notices:", error);
       throw error;
@@ -61,12 +56,8 @@ export default function NoticesPage() {
 
   const searchNotices = async () => {
     try {
-      const res = await axiosInstance.get<Notice[]>("/notice/search", {
-        params: {
-          keyword: searchQuery,
-        },
-      });
-      const sortedNotices = [...res.data].sort(
+      const data = await noticeApi.searchNotices<Notice[]>(searchQuery);
+      const sortedNotices = [...data].sort(
         (a, b) => b.noticeId - a.noticeId
       );
       setNotices(sortedNotices);

--- a/src/page/problems/index.tsx
+++ b/src/page/problems/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import axiosInstance from "../../api/axiosInstance";
+import problemApi from "../../api/problemApi";
 import * as S from "./style";
 import { Header } from "../../components/header";
 import { Footer } from "../../components/footer";
@@ -123,8 +123,13 @@ export default function Problems() {
         params.name = searchTerm;
       }
 
-      const response = await axiosInstance.get(`/problems`, { params });
-      const { content, totalPages: tp, first, last } = response.data;
+      const data = await problemApi.getProblems<{
+        content: unknown[];
+        totalPages: number;
+        first: boolean;
+        last: boolean;
+      }>(params);
+      const { content, totalPages: tp, first, last } = data;
 
       mapProblems(content || []);
       setTotalPages(tp || 0);

--- a/src/page/profile/index.tsx
+++ b/src/page/profile/index.tsx
@@ -18,7 +18,7 @@ import {
   StreakCard,
   HeatmapCard,
 } from "../../components/profile";
-import axiosInstance from "../../api/axiosInstance";
+import userApi from "../../api/userApi";
 
 interface UserData {
   id?: number;
@@ -172,7 +172,7 @@ const Profile = () => {
 
   const handleLogout = async () => {
     try {
-      await axiosInstance.post("/user/logout");
+      await userApi.logout();
     } catch (error) {
       console.error("Logout failed:", error);
     } finally {
@@ -187,7 +187,7 @@ const Profile = () => {
 
   const handleDeleteAccount = async () => {
     try {
-      await axiosInstance.delete("/user/delete");
+      await userApi.deleteAccount();
       localStorage.removeItem("accessToken");
       localStorage.removeItem("refreshToken");
       window.location.assign("/");
@@ -222,22 +222,17 @@ const Profile = () => {
 
         const [userResponse, contributionsResponse, streakResponse] =
           await Promise.all([
-            axiosInstance.get<UserData>("/user"),
-            axiosInstance.get<ContributionsResponse>(
-              "/user/activity/contributions",
-              {
-                params: {
-                  start: formatDate(startDate),
-                  end: formatDate(endDate),
-                },
-              },
+            userApi.getUser<UserData>(),
+            userApi.getContributions<ContributionsResponse>(
+              formatDate(startDate),
+              formatDate(endDate),
             ),
-            axiosInstance.get<StreakResponse>("/user/activity/streak"),
+            userApi.getStreak<StreakResponse>(),
           ]);
 
         const userData =
-          (userResponse.data as UserData & { data?: UserData })?.data ||
-          userResponse.data;
+          (userResponse as UserData & { data?: UserData })?.data ||
+          userResponse;
 
         if (userData?.name || userData?.nickname) {
           setName(userData.name || userData.nickname || "");
@@ -246,12 +241,12 @@ const Profile = () => {
           setScore(userData.score);
         }
 
-        const contributionsData = contributionsResponse.data || {};
+        const contributionsData = contributionsResponse || {};
         setHeatmapData(generateHeatmapData(contributionsData));
 
         const streakData =
-          (streakResponse.data as StreakResponse & { data?: StreakResponse })
-            ?.data || streakResponse.data;
+          (streakResponse as StreakResponse & { data?: StreakResponse })
+            ?.data || streakResponse;
         setStreak(
           typeof streakData?.streak === "number" ? streakData.streak : 0,
         );


### PR DESCRIPTION
## 관련 이슈
- Resolves #76 

## 변경 내용
- 도메인별 api 모듈 5개 신설: contestApi, courseApi, noticeApi, problemApi, userApi 
- 11개 파일에 흩어져 있던 axiosInstance 직접 호출 37곳을 전부 모듈 함수 호출로 교체
- useContest 훅의 변칙 호출 정리 — API_BASE_URL 절대경로 + Authorization 헤더 수동 부착을 제거하고 인터셉터를 타도록 변경
- 대회 상세 조회에 contestCode 가드 추가 — 기존에는 contestCode가 없으면 /contest/undefined로 요청이 나갔음

## 작업 목적
- 엔드포인트/응답 구조 변경 시 수정 지점을 api 모듈 한 곳으로 제한 
- 후속 작업인 에러 처리 규칙 통일을 api 층에 일괄 적용하기 위한 선행 작업

## 테스트 방법
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [x] Breaking Changes가 없습니다

## 기타 사항
- #76 체크리스트 마지막 항목인 페이지마다 중복 선언된 응답 인터페이스의 api 모듈 통합은 이 PR에서 제외했습니다 — 서버 #63 반영 시 타입이 바뀔 예정이라 그때 함께 정리할 것입니다.
- solve 페이지 3곳의 기존 타입 에러(react-hook-form Control)는 이 PR 범위 밖이라 손대지 않았습니다. 별도로 이슈 팔 예정입니다